### PR TITLE
✨ locking mechanism: prevent parallel access to git-nest configuration

### DIFF
--- a/actions/add.go
+++ b/actions/add.go
@@ -9,7 +9,6 @@ import (
 	"github.com/jeftadlvw/git-nest/migrations/git"
 	"github.com/jeftadlvw/git-nest/models"
 	"github.com/jeftadlvw/git-nest/models/urls"
-	"os"
 	"path/filepath"
 	"strings"
 )
@@ -37,7 +36,6 @@ func AddSubmoduleInContext(context *models.NestContext, url urls.HttpUrl, ref st
 	// if cloneDir is empty, set it to repository name
 	// if cloneDir has trailing separator, append repository name
 	if strings.HasSuffix(string(cloneDir), string(filepath.Separator)) {
-		fmt.Println("has suffix")
 		cloneDir = cloneDir.SJoin(repositoryName)
 	} else if cloneDir.Empty() {
 		cloneDir = models.Path(repositoryName)
@@ -56,18 +54,11 @@ func AddSubmoduleInContext(context *models.NestContext, url urls.HttpUrl, ref st
 	// join project root and absolute path, check if it's not an existing file and create that directory
 	absolutePath = context.ProjectRoot.Join(relativeToRoot)
 
-	if !absolutePath.Exists() {
-		err = os.MkdirAll(absolutePath.String(), os.ModePerm)
-		if err != nil {
-			return nil, fmt.Errorf("internal error: could not create directory %s: %w", absolutePath, err)
-		}
-	} else {
-		if absolutePath.IsFile() {
-			return nil, fmt.Errorf("validation error: %s is a file", cloneDir)
-		}
-		if absolutePath.BContains("*") {
-			return nil, fmt.Errorf("validation error: %s is not empty", cloneDir)
-		}
+	if absolutePath.IsFile() {
+		return nil, fmt.Errorf("validation error: %s is a file", cloneDir)
+	}
+	if absolutePath.BContains("*") {
+		return nil, fmt.Errorf("validation error: directory %s is not empty", cloneDir)
 	}
 
 	newSubmodule := models.Submodule{

--- a/internal/constants/lockfile.go
+++ b/internal/constants/lockfile.go
@@ -1,0 +1,18 @@
+package constants
+
+/*
+LockFileName contains the path string to the project-local lockfile.
+*/
+const LockFileName = "~git-nest.lock"
+
+/*
+LockFileNameGitRepo contains the path string to the project-local lockfile if the project is a git repository.
+*/
+const LockFileNameGitRepo = ".git/~git-nest.lock"
+
+/*
+LockFileContents contains the contents of the lockfile in case someone opens it.
+*/
+const LockFileContents = `git-nest lockfile
+Manual removal could lead to data loss in the git-nest configuration.
+Do not remove except you know what you're' doing!\n`

--- a/internal/constants/lockfile.go
+++ b/internal/constants/lockfile.go
@@ -6,11 +6,6 @@ LockFileName contains the path string to the project-local lockfile.
 const LockFileName = "~git-nest.lock"
 
 /*
-LockFileNameGitRepo contains the path string to the project-local lockfile if the project is a git repository.
-*/
-const LockFileNameGitRepo = ".git/~git-nest.lock"
-
-/*
 LockFileContents contains the contents of the lockfile in case someone opens it.
 */
 const LockFileContents = `git-nest lockfile

--- a/internal/create_context.go
+++ b/internal/create_context.go
@@ -48,6 +48,7 @@ func CreateContext(p models.Path) (models.NestContext, error) {
 	configStr, err := utils.ReadFileToStr(configFilePath)
 	if err == nil {
 		configFileExists = true
+		configStr = ""
 	}
 
 	// populate configuration struct if a configuration file exists,
@@ -77,6 +78,9 @@ func CreateContext(p models.Path) (models.NestContext, error) {
 		}
 	}
 
+	// calculate checksum of configuration file content
+	configFileChecksum := utils.CalculateChecksumS(configStr)
+
 	nestContext.WorkingDirectory = p
 	nestContext.ProjectRoot = projectRoot
 	nestContext.ConfigFileExists = configFileExists
@@ -85,6 +89,7 @@ func CreateContext(p models.Path) (models.NestContext, error) {
 	nestContext.IsGitInstalled = IsGitInstalled
 	nestContext.IsGitRepository = isGitProject
 	nestContext.GitRepositoryRoot = gitRoot
+	nestContext.Checksums.ConfigurationFile = configFileChecksum
 
 	return nestContext, nil
 }

--- a/internal/create_context.go
+++ b/internal/create_context.go
@@ -48,6 +48,7 @@ func CreateContext(p models.Path) (models.NestContext, error) {
 	configStr, err := utils.ReadFileToStr(configFilePath)
 	if err == nil {
 		configFileExists = true
+	} else {
 		configStr = ""
 	}
 

--- a/internal/create_context.go
+++ b/internal/create_context.go
@@ -23,6 +23,7 @@ func CreateContext(p models.Path) (models.NestContext, error) {
 		gitRoot          models.Path
 		IsGitInstalled   bool
 		isGitProject     bool
+		err              error
 	)
 
 	nestContext := models.NestContext{}
@@ -32,7 +33,7 @@ func CreateContext(p models.Path) (models.NestContext, error) {
 	}
 
 	// evaluate project root
-	projectRoot, err := FindProjectRoot(p)
+	projectRoot, err = FindProjectRoot(p)
 	if err != nil {
 		projectRoot = p
 	}

--- a/internal/lockfile.go
+++ b/internal/lockfile.go
@@ -1,0 +1,62 @@
+package internal
+
+import (
+	"errors"
+	"fmt"
+	"github.com/jeftadlvw/git-nest/internal/constants"
+	"github.com/jeftadlvw/git-nest/models"
+	"github.com/jeftadlvw/git-nest/utils"
+	"os"
+)
+
+/*
+AcquireLockFile tries to acquire a context-specific lockfile.
+It returns if the lockfile was acquired successfully.
+*/
+func AcquireLockFile(c models.NestContext) (bool, error) {
+	lockFilePath := getLockFilePath(c.IsGitRepository, c.ProjectRoot)
+
+	if lockFilePath.IsDir() {
+		return false, errors.New("lock file is directory")
+	}
+
+	if lockFilePath.IsFile() {
+		return false, nil
+	}
+
+	err := utils.WriteStrToFile(lockFilePath, constants.LockFileContents)
+	if err != nil {
+		return false, fmt.Errorf("could not write lockfile: %w", err)
+	}
+
+	return true, nil
+}
+
+/*
+ReleaseLockFile releases the context-specific lockfile.
+*/
+func ReleaseLockFile(c models.NestContext) error {
+	lockFilePath := getLockFilePath(c.IsGitRepository, c.ProjectRoot)
+
+	if lockFilePath.IsDir() {
+		return errors.New("lock file is directory")
+	}
+
+	if lockFilePath.IsFile() {
+		err := os.Remove(lockFilePath.String())
+		if err != nil {
+			return fmt.Errorf("could not remove lock file: %w", err)
+		}
+	}
+
+	return nil
+
+}
+
+func getLockFilePath(isGitRepository bool, projectRoot models.Path) models.Path {
+	if isGitRepository {
+		return projectRoot.SJoin(constants.LockFileNameGitRepo)
+	}
+
+	return projectRoot.SJoin(constants.LockFileName)
+}

--- a/internal/tests/lockfile_test.go
+++ b/internal/tests/lockfile_test.go
@@ -1,0 +1,137 @@
+package tests
+
+import (
+	"fmt"
+	"github.com/jeftadlvw/git-nest/internal"
+	"github.com/jeftadlvw/git-nest/internal/constants"
+	"github.com/jeftadlvw/git-nest/models"
+	"github.com/jeftadlvw/git-nest/utils"
+	"os"
+	"testing"
+)
+
+func TestAcquireLockFile(t *testing.T) {
+
+	cases := []struct {
+		createFile              bool
+		createDir               bool
+		isGitRepositoryOverride bool
+		expectedFile            string
+		success                 bool
+		err                     bool
+	}{
+		{false, false, false, constants.LockFileName, true, false},
+		{false, false, true, constants.LockFileNameGitRepo, true, false},
+		{true, false, false, constants.LockFileName, false, false},
+		{true, false, true, constants.LockFileNameGitRepo, false, false},
+		{true, true, false, constants.LockFileName, false, true},
+		{true, true, true, constants.LockFileNameGitRepo, false, true},
+	}
+
+	for index, tc := range cases {
+		t.Run(fmt.Sprintf("TestAcquireLockFile-%d", index+1), func(t *testing.T) {
+			tempDir := models.Path(t.TempDir())
+			context, err := internal.CreateContext(tempDir)
+			if err != nil {
+				t.Fatalf("could not create temporary context: %s", err)
+			}
+
+			context.IsGitRepository = tc.isGitRepositoryOverride
+			if tc.isGitRepositoryOverride {
+				err = os.MkdirAll(context.ProjectRoot.String()+"/.git", os.ModePerm)
+				if err != nil {
+					t.Fatalf("could not create mock .git directory: %s", err)
+				}
+			}
+
+			if tc.createDir {
+				err = os.MkdirAll(context.ProjectRoot.String()+"/"+tc.expectedFile, os.ModePerm)
+				if err != nil {
+					t.Fatalf("could not create mock directory: %s", err)
+				}
+			}
+
+			if !tc.createDir && tc.createFile {
+				err = utils.WriteStrToFile(context.ProjectRoot.SJoin(tc.expectedFile), "")
+				if err != nil {
+					t.Fatalf("could not create mock lock file: %s", err)
+				}
+			}
+
+			success, err := internal.AcquireLockFile(context)
+			// test for errors
+			if tc.err && err == nil {
+				t.Fatalf("no error, but expected one")
+			}
+			if !tc.err && err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			if tc.success && !success {
+				t.Fatalf("expected success, but wasn't")
+			}
+			if !tc.success && success {
+				t.Fatalf("expected failure, but wasn't")
+			}
+		})
+	}
+}
+
+func TestReleaseLockFile(t *testing.T) {
+
+	cases := []struct {
+		createFile              bool
+		createDir               bool
+		isGitRepositoryOverride bool
+		expectedFile            string
+		err                     bool
+	}{
+		{false, false, false, constants.LockFileName, false},
+		{false, false, true, constants.LockFileNameGitRepo, false},
+		{true, false, false, constants.LockFileName, false},
+		{true, false, true, constants.LockFileNameGitRepo, false},
+		{true, true, false, constants.LockFileName, true},
+		{true, true, true, constants.LockFileNameGitRepo, true},
+	}
+
+	for index, tc := range cases {
+		t.Run(fmt.Sprintf("ReleaseLockFile-%d", index+1), func(t *testing.T) {
+			tempDir := models.Path(t.TempDir())
+			context, err := internal.CreateContext(tempDir)
+			if err != nil {
+				t.Fatalf("could not create temporary context: %s", err)
+			}
+
+			context.IsGitRepository = tc.isGitRepositoryOverride
+			if tc.isGitRepositoryOverride {
+				err = os.MkdirAll(context.ProjectRoot.String()+"/.git", os.ModePerm)
+				if err != nil {
+					t.Fatalf("could not create mock .git directory: %s", err)
+				}
+			}
+
+			if tc.createDir {
+				err = os.MkdirAll(context.ProjectRoot.String()+"/"+tc.expectedFile, os.ModePerm)
+				if err != nil {
+					t.Fatalf("could not create mock directory: %s", err)
+				}
+			}
+
+			if !tc.createDir && tc.createFile {
+				err = utils.WriteStrToFile(context.ProjectRoot.SJoin(tc.expectedFile), "")
+				if err != nil {
+					t.Fatalf("could not create mock lock file: %s", err)
+				}
+			}
+
+			err = internal.ReleaseLockFile(context)
+			// test for errors
+			if tc.err && err == nil {
+				t.Fatalf("no error, but expected one")
+			}
+			if !tc.err && err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+		})
+	}
+}

--- a/internal/tests/toml_test.go
+++ b/internal/tests/toml_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"fmt"
 	"github.com/jeftadlvw/git-nest/internal"
 	"github.com/jeftadlvw/git-nest/models"
 	"github.com/jeftadlvw/git-nest/models/urls"
@@ -107,8 +106,6 @@ func TestSubmoduleToTomlConfig(t *testing.T) {
 	if output := internal.SubmoduleToTomlConfig(submodule, indent); output != expectedOutput {
 		t.Fatalf("\nExpected:\n>%s<\n\nActual:\n>%s<", expectedOutput, output)
 	}
-
-	fmt.Println("2------")
 
 	// windows path style
 	submodule = models.Submodule{"example\\path", &urls.HttpUrl{"example.com", 443, "", true}, "example-ref"}

--- a/internal/tests/write_config_test.go
+++ b/internal/tests/write_config_test.go
@@ -220,21 +220,25 @@ func TestWriteProjectConfigFiles(t *testing.T) {
 
 		modulesExist := len(context.Config.Submodules) != 0
 
-		gitExcludeWritten, configWritten, gitExcludeWriteErr, configWriteErr := internal.WriteProjectConfigFiles(context)
+		r, err := internal.WriteProjectConfigFiles(context)
 
-		if gitExcludeWriteErr != nil {
-			t.Fatalf("writing to git exclude failed: %s", gitExcludeWriteErr)
+		if err != nil {
+			t.Fatalf("failed to write project config files: %s", err)
 		}
 
-		if configWriteErr != nil {
-			t.Fatalf("writing to config file failed: %s", configWriteErr)
+		if r.GitExcludeWriteError != nil {
+			t.Fatalf("writing to git exclude failed: %s", r.GitExcludeWriteError)
 		}
 
-		if !gitExcludeWritten {
+		if r.ConfigWriteError != nil {
+			t.Fatalf("writing to config file failed: %s", r.ConfigWriteError)
+		}
+
+		if !r.GitExcludeWritten {
 			t.Fatalf("should've written to git exclude")
 		}
 
-		if !configWritten {
+		if !r.ConfigWritten {
 			t.Fatalf("should've written to configuration file")
 		}
 
@@ -285,21 +289,25 @@ func TestWriteProjectConfigFiles(t *testing.T) {
 
 		modulesExist := len(context.Config.Submodules) != 0
 
-		gitExcludeWritten, configWritten, gitExcludeWriteErr, configWriteErr := internal.WriteProjectConfigFiles(context)
+		r, err := internal.WriteProjectConfigFiles(context)
 
-		if gitExcludeWriteErr != nil {
-			t.Fatalf("writing to git exclude failed, and should've never happened: %s", gitExcludeWriteErr)
+		if err != nil {
+			t.Fatalf("failed to write project config files: %s", err)
 		}
 
-		if configWriteErr != nil {
-			t.Fatalf("writing to config file failed: %s", configWriteErr)
+		if r.GitExcludeWriteError != nil {
+			t.Fatalf("writing to git exclude failed, and should've never happened: %s", r.GitExcludeWriteError)
 		}
 
-		if gitExcludeWritten {
-			t.Fatalf("should not have written to git exclude")
+		if r.ConfigWriteError != nil {
+			t.Fatalf("writing to config file failed: %s", r.ConfigWriteError)
 		}
 
-		if !configWritten {
+		if r.GitExcludeWritten {
+			t.Fatalf("should've written to git exclude")
+		}
+
+		if !r.ConfigWritten {
 			t.Fatalf("should've written to configuration file")
 		}
 

--- a/migrations/context/write_config_files.go
+++ b/migrations/context/write_config_files.go
@@ -11,13 +11,13 @@ type WriteConfigFiles struct {
 }
 
 func (m WriteConfigFiles) Migrate() error {
-	var err error
-
-	_, _, err1, err2 := internal.WriteProjectConfigFiles(*m.Context)
-	if err1 != nil {
-		err = err1
-	} else if err2 != nil {
-		err = err2
+	r, err := internal.WriteProjectConfigFiles(*m.Context)
+	if err == nil {
+		if r.ConfigWriteError != nil {
+			err = r.ConfigWriteError
+		} else if r.GitExcludeWriteError != nil {
+			err = r.GitExcludeWriteError
+		}
 	}
 
 	if err != nil {

--- a/migrations/git/clone.go
+++ b/migrations/git/clone.go
@@ -5,6 +5,7 @@ import (
 	"github.com/jeftadlvw/git-nest/interfaces"
 	"github.com/jeftadlvw/git-nest/models"
 	"github.com/jeftadlvw/git-nest/utils"
+	"os"
 )
 
 type Clone struct {
@@ -14,6 +15,14 @@ type Clone struct {
 }
 
 func (m Clone) Migrate() error {
+
+	if !m.Path.Exists() {
+		err := os.MkdirAll(m.Path.String(), os.ModePerm)
+		if err != nil {
+			return fmt.Errorf("internal error: could not create directory %s: %w", m.Path, err)
+		}
+	}
+
 	err := utils.CloneGitRepository(m.Url.String(), m.Path, m.CloneDirName)
 	if err != nil {
 		return fmt.Errorf("error while cloning into %s: %s", m.Path.SJoin(m.CloneDirName), err)

--- a/models/checksums.go
+++ b/models/checksums.go
@@ -1,0 +1,18 @@
+package models
+
+/*
+Checksums contains checksums for required files at startup
+*/
+type Checksums struct {
+	/*
+		ConfigurationFile contains the checksum for the `nestmodules.toml` configuration file.
+	*/
+	ConfigurationFile string
+}
+
+/*
+Validate performs validation on this Config.
+*/
+func (c Checksums) Validate() error {
+	return nil
+}

--- a/models/nest_context.go
+++ b/models/nest_context.go
@@ -43,6 +43,11 @@ type NestContext struct {
 	Config NestConfig
 
 	/*
+		Checksums contains checksums of every configuration file's contents.
+	*/
+	Checksums Checksums
+
+	/*
 		IsGitInstalled defines whether git is installed in the current environment.
 	*/
 	IsGitInstalled bool

--- a/models/tests/checksums_test.go
+++ b/models/tests/checksums_test.go
@@ -1,0 +1,1 @@
+package tests

--- a/utils/checksum.go
+++ b/utils/checksum.go
@@ -1,0 +1,40 @@
+package utils
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"github.com/jeftadlvw/git-nest/models"
+	"io"
+	"os"
+)
+
+/*
+CalculateChecksumS calculates the checksum of a given string.
+*/
+func CalculateChecksumS(s string) string {
+	h := sha256.New()
+	h.Write([]byte(s))
+	return fmt.Sprintf("%x", h.Sum(nil))
+}
+
+/*
+CalculateChecksumF calculates the checksum of a given file.
+*/
+func CalculateChecksumF(path models.Path) (string, error) {
+	if !path.IsFile() {
+		return "", fmt.Errorf("%s is not a file", path.String())
+	}
+
+	f, err := os.Open(path.String())
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err = io.Copy(h, f); err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%x", h.Sum(nil)), nil
+}

--- a/utils/file.go
+++ b/utils/file.go
@@ -26,5 +26,9 @@ func ReadFileToStr(path models.Path) (string, error) {
 WriteStrToFile is a wrapper for os.WriteFile.
 */
 func WriteStrToFile(path models.Path, str string) error {
+	if path.IsDir() {
+		return fmt.Errorf("%s is a directory", path.String())
+	}
+
 	return os.WriteFile(path.String(), []byte(str), 0644)
 }

--- a/utils/tests/checksum_test.go
+++ b/utils/tests/checksum_test.go
@@ -66,13 +66,17 @@ func TestCalculateChecksumF(t *testing.T) {
 			}
 
 			expectedChecksum := fmt.Sprintf("%x", h.Sum(nil))
-			checksum, err := utils.CalculateChecksumF(tempFile)
+			checksumString := utils.CalculateChecksumS(tc.input)
+			checksumFile, err := utils.CalculateChecksumF(tempFile)
 			if err != nil {
-				t.Fatalf("error calculating checksum: %s", err)
+				t.Fatalf("error calculating checksum for file: %s", err)
 			}
 
-			if checksum != expectedChecksum {
-				t.Fatalf("checksums do not match: expected: %s, got: %s", expectedChecksum, checksum)
+			if checksumFile != expectedChecksum {
+				t.Fatalf("checksums do not match: expected: %s, got: %s", expectedChecksum, checksumFile)
+			}
+			if checksumFile != checksumString {
+				t.Fatalf("unequal checksums for file and string: %s != %s", checksumFile, checksumString)
 			}
 		})
 	}

--- a/utils/tests/checksum_test.go
+++ b/utils/tests/checksum_test.go
@@ -1,0 +1,79 @@
+package tests
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"github.com/jeftadlvw/git-nest/models"
+	"github.com/jeftadlvw/git-nest/utils"
+	"io"
+	"os"
+	"testing"
+)
+
+func TestCalculateChecksumS(t *testing.T) {
+	cases := []struct {
+		input string
+	}{
+		{""},
+		{"foo"},
+		{"7ßijß8m aß 8nads84654f687gspoilömxöoijasoiu8s ()(/)ASDnja s"},
+	}
+
+	for index, tc := range cases {
+		t.Run(fmt.Sprintf("TestCalculateChecksumS-%d", index+1), func(t *testing.T) {
+			h := sha256.New()
+			h.Write([]byte(tc.input))
+
+			expectedChecksum := fmt.Sprintf("%x", h.Sum(nil))
+			checksum := utils.CalculateChecksumS(tc.input)
+
+			if checksum != expectedChecksum {
+				t.Fatalf("checksums do not match: expected: %s, got: %s", expectedChecksum, checksum)
+			}
+		})
+	}
+}
+
+func TestCalculateChecksumF(t *testing.T) {
+	cases := []struct {
+		input string
+	}{
+		{""},
+		{"foo"},
+		{"7ßijß8m aß 8nads84654f687gspoilömxöoijasoiu8s ()(/)ASDnja s"},
+	}
+
+	for index, tc := range cases {
+		t.Run(fmt.Sprintf("TestCalculateChecksumF-%d", index+1), func(t *testing.T) {
+
+			tempDir := models.Path(t.TempDir())
+			tempFile := tempDir.SJoin("checksum.txt")
+
+			err := utils.WriteStrToFile(tempFile, tc.input)
+			if err != nil {
+				t.Fatalf("error writing temporary file: %s", err)
+			}
+
+			f, err := os.Open(tempFile.String())
+			if err != nil {
+				t.Fatalf("error opening temporary file: %s", err)
+			}
+			defer f.Close()
+
+			h := sha256.New()
+			if _, err = io.Copy(h, f); err != nil {
+				t.Fatalf("error reading temporary file: %s", err)
+			}
+
+			expectedChecksum := fmt.Sprintf("%x", h.Sum(nil))
+			checksum, err := utils.CalculateChecksumF(tempFile)
+			if err != nil {
+				t.Fatalf("error calculating checksum: %s", err)
+			}
+
+			if checksum != expectedChecksum {
+				t.Fatalf("checksums do not match: expected: %s, got: %s", expectedChecksum, checksum)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This pull requests add some locking behaviour to the core of git-nest. It needs to be called in each subcommand that performs writing operations on the context.

Unfortunately, it also adds some more boilerplate to writing subcommans...

Closes #21 